### PR TITLE
Proposition: Add link to open-source R textbook

### DIFF
--- a/Finance.md
+++ b/Finance.md
@@ -327,7 +327,6 @@ Views](https://github.com/cran-task-views) repo for details.
 ### Links
 -   [Rmetrics contains a wealth of R code for Finance](http://www.rmetrics.org)
 -   [Quantlib is a C++ library for quantitative finance](http://www.quantlib.org)
--   [Open-source textbook "Tidy Finance with R" provides a codebase for many applications in empirical finance](http://www.tidy-finance.org//)
 -   [Documentation for the Bloomberg API accessed by Rblpapi](http://www.bloomberglabs.com//)
 -   [Mailing list: R Special Interest Group Finance](https://stat.ethz.ch/mailman/listinfo/R-SIG-Finance/)
 -   [MSCI indexes data](http://www.msci.com/)
@@ -337,3 +336,4 @@ Views](https://github.com/cran-task-views) repo for details.
 -   [Eric Zivot](http://faculty.washington.edu/ezivot/splus.htm)
 -   [R Code for Ruppert's 'Statistics and Finance'](http://christopherggreen.github.io/RuppertStatisticsFinance2004/)
 -   [Guy Yollin](http://www.r-programming.org/papers)
+-   [Textbook "Tidy Finance with R" with many empirical finance applications](http://www.tidy-finance.org//)

--- a/Finance.md
+++ b/Finance.md
@@ -327,6 +327,7 @@ Views](https://github.com/cran-task-views) repo for details.
 ### Links
 -   [Rmetrics contains a wealth of R code for Finance](http://www.rmetrics.org)
 -   [Quantlib is a C++ library for quantitative finance](http://www.quantlib.org)
+-   [Open-source textbook "Tidy Finance with R" provides a codebase for many applications in empirical finance](http://www.tidy-finance.org//)
 -   [Documentation for the Bloomberg API accessed by Rblpapi](http://www.bloomberglabs.com//)
 -   [Mailing list: R Special Interest Group Finance](https://stat.ethz.ch/mailman/listinfo/R-SIG-Finance/)
 -   [MSCI indexes data](http://www.msci.com/)


### PR DESCRIPTION
I propose to add a link to the open source textbook "Tidy Finance with R" (print release with CRC Press in 2023) in which we provide code for "common" tasks such as CRSP/Compustat cleaning, portfolio sorts, portfolio optimization and much more. I hope the addition is of interest to the readers of the task view "Empirical Finance".