### PR TITLE
Added talib-package (Second attempt)

### DIFF
--- a/Finance.md
+++ b/Finance.md
@@ -119,6 +119,7 @@ Views](https://github.com/cran-task-views) repo for details.
 -   The `r pkg("PerformanceAnalytics", priority = "core")` package contains a large number of
     functions for portfolio performance calculations and risk management.
 -   The `r pkg("TTR")` contains functions to construct technical trading rules in R.
+-   The `r pkg("talib")` package wraps TA-Lib for technical analysis and candlestick pattern recognition.
 -   The `r pkg("sde")` package provides simulation and inference functionality for stochastic
     differential equations.
 -   The `r pkg("vrtest")` package contains a number of variance ratio tests for the weak-form of the


### PR DESCRIPTION
Hi @eddelbuettel,

This time the package is actually on CRAN: https://cran.r-project.org/web/packages/talib/index.html :smile: 
- I took the liberty to add it below TTR as the two are similar in what it solves for the community. I dont recall any objections to it from my last PR, so I took it as an approval of it. 

Best,
 